### PR TITLE
Do not customize BaseIntermediateOutputPath since that prevents tests…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(Configuration)\$(MSBuildProjectName)</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(Configuration)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <UseCommonOutputDirectory>False</UseCommonOutputDirectory>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/Woohoo.Agi.Interpreter.UnitTest/Resources/Serialization/LzwDecompressUnitTest.cs
+++ b/src/Woohoo.Agi.Interpreter.UnitTest/Resources/Serialization/LzwDecompressUnitTest.cs
@@ -20,6 +20,8 @@ namespace Woohoo.Agi.Resources.Serialization.UnitTest
             Action act = () => decompress.Decompress(null, 0, 0, 0);
 
             act.Should().Throw<ArgumentNullException>();
+
+            true.Should().BeFalse();
         }
 
         [TestMethod]

--- a/src/Woohoo.Agi.Interpreter.UnitTest/Resources/Serialization/LzwDecompressUnitTest.cs
+++ b/src/Woohoo.Agi.Interpreter.UnitTest/Resources/Serialization/LzwDecompressUnitTest.cs
@@ -20,8 +20,6 @@ namespace Woohoo.Agi.Resources.Serialization.UnitTest
             Action act = () => decompress.Decompress(null, 0, 0, 0);
 
             act.Should().Throw<ArgumentNullException>();
-
-            true.Should().BeFalse();
         }
 
         [TestMethod]


### PR DESCRIPTION
… from being discovered by dotnet test.